### PR TITLE
Add scope parameter to oauth request

### DIFF
--- a/sentry_auth_gitlab/constants.py
+++ b/sentry_auth_gitlab/constants.py
@@ -12,3 +12,5 @@ API_VERSION = getattr(settings, 'GITLAB_API_VERSION', 3)
 ACCESS_TOKEN_URL = '{0}://{1}/oauth/token'.format(SCHEME, BASE_DOMAIN)
 AUTHORIZE_URL = '{0}://{1}/oauth/authorize'.format(SCHEME, BASE_DOMAIN)
 API_BASE_URL = '{0}://{1}/api/v{2}'.format(SCHEME, BASE_DOMAIN, API_VERSION)
+
+SCOPE = 'read_user'

--- a/sentry_auth_gitlab/provider.py
+++ b/sentry_auth_gitlab/provider.py
@@ -5,7 +5,7 @@ from sentry.auth.providers.oauth2 import (
 )
 
 from .constants import (
-    AUTHORIZE_URL, ACCESS_TOKEN_URL, CLIENT_ID, CLIENT_SECRET
+    AUTHORIZE_URL, ACCESS_TOKEN_URL, CLIENT_ID, CLIENT_SECRET, SCOPE
 )
 from .views import FetchUser
 
@@ -15,7 +15,7 @@ class GitLabOAuth2Provider(OAuth2Provider):
 
     def get_auth_pipeline(self):
         return [
-            OAuth2Login(AUTHORIZE_URL, client_id=CLIENT_ID),
+            OAuth2Login(AUTHORIZE_URL, client_id=CLIENT_ID, scope=SCOPE),
             OAuth2Callback(
                 access_token_url=ACCESS_TOKEN_URL,
                 client_id=CLIENT_ID, client_secret=CLIENT_SECRET,


### PR DESCRIPTION
When I try to use this plugin with sentry 8.15 and gitlab 9.0, gitlab reports a error in authorize step.

> An error has occurred
> The requested scope is invalid, unknown, or malformed.

So I added the scope parameter in oauth request.