### PR TITLE
client: Create a new HTTP session for each request

### DIFF
--- a/sentry_auth_gitlab/client.py
+++ b/sentry_auth_gitlab/client.py
@@ -14,14 +14,13 @@ class GitLabApiError(Exception):
 
 
 class GitLabClient(object):
-    http = http.build_session()
-
     def _request(self, path, access_token):
+        session = http.build_session()
         headers = {'Authorization': 'Bearer {0}'.format(access_token)}
         url = '{0}/{1}'.format(API_BASE_URL, path.lstrip('/'))
 
         try:
-            req = self.http.get(url, headers=headers)
+            req = session.get(url, headers=headers)
         except RequestException as e:
             raise GitLabApiError(unicode(e), status=e.status_code)
         return json.loads(req.content)

--- a/sentry_auth_gitlab/client.py
+++ b/sentry_auth_gitlab/client.py
@@ -22,7 +22,7 @@ class GitLabClient(object):
         try:
             req = session.get(url, headers=headers)
         except RequestException as e:
-            raise GitLabApiError(unicode(e), status=e.status_code)
+            raise GitLabApiError(unicode(e), status=getattr(e, 'status_code', None))
         return json.loads(req.content)
 
     def get_user(self, access_token):


### PR DESCRIPTION
The globally shared connection resets after some time. When it's reset, the web worker will optimistically try to use it anyway, and fail with a connection error.

WIth many web workers running behind a load balancer, this means that a huge portion of login requests would randomly land on a broken session and it was common for people to need to retry 3-4 times until their login attempt finally worked.

You can see here how within the sentry project's own code, sessions are created on demand instead of being shared globally: https://github.com/getsentry/sentry/blob/27cc0fed47732dec907668a4529ca39bb384bf5a/src/sentry/http.py#L271